### PR TITLE
Refactor AWS dependencies and add Secrets Manager configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,10 +185,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>iam</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>secretsmanager</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     </developers>
 
     <properties>
-        <java-compat.version>17</java-compat.version>
+        <java-compat.version>11</java-compat.version>
         <kafka.version>2.8.2</kafka.version>
         <dcp-client.version>0.51.0</dcp-client.version>
         <java-client.version>3.7.1</java-client.version>
@@ -183,6 +183,18 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>iam</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -222,7 +234,7 @@
                 To refresh the generated docs, run:
                     mvn clean test-compile exec:java
              -->
-            <plugin>
+            <!-- <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
@@ -230,7 +242,7 @@
                     <mainClass>com.couchbase.connect.kafka.util.config.AsciiDocGenerator</mainClass>
                     <classpathScope>test</classpathScope>
                 </configuration>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -249,7 +261,7 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
+            <!-- <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
@@ -292,8 +304,10 @@
                             <head>Implementation Note:</head>
                         </tag>
                     </tags>
+                    <doclint>none</doclint>
+                    <source>8</source>
                 </configuration>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>io.confluent</groupId>
                 <version>0.12.0</version>

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfig.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.amazonaws.kafka.config.providers;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.ValidString;
+
+import com.amazonaws.kafka.config.providers.common.CommonConfigUtils;
+
+public class SecretsManagerConfig extends AbstractConfig {
+
+    public static final String NOT_FOUND_STRATEGY = "NotFoundStrategy";
+    public static final String NOT_FOUND_FAIL = "fail";
+    public static final String NOT_FOUND_IGNORE = "ignore";
+
+    private static final String NOT_FOUND_STRATEGY_DOC = "An action to take in case a secret cannot be found. "
+            + "Possible actions are: `ignore` and `fail`. <br>"
+            + "If `ignore` is selected and a secret cannot be found, the empty string will be assigned to a parameter.<br>"
+            + "If `fail` is selected, the config provider will throw an exception to signal the issue.<br>"
+            + "If there is a connectivity or access issue with AWS Secrets Manager service, an exception will be thrown.";
+
+    public SecretsManagerConfig(Map<?, ?> originals) {
+        super(config(), originals);
+    }
+
+    private static ConfigDef config() {
+        return new ConfigDef(CommonConfigUtils.COMMON_CONFIG)
+                .define(
+                        NOT_FOUND_STRATEGY,
+                        ConfigDef.Type.STRING,
+                        NOT_FOUND_IGNORE,
+                        ValidString.in(NOT_FOUND_FAIL, NOT_FOUND_IGNORE),
+                        ConfigDef.Importance.LOW,
+                        NOT_FOUND_STRATEGY_DOC);
+    }
+}

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.amazonaws.kafka.config.providers;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.common.config.ConfigChangeCallback;
+import org.apache.kafka.common.config.ConfigData;
+import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.kafka.config.providers.common.AwsServiceConfigProvider;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+/**
+ * This class implements a ConfigProvider for AWS Secrets Manager.<br>
+ *
+ * <p>
+ * <b>Usage:</b><br>
+ * In a configuration file (e.g. {@code client.properties}) define following
+ * properties:<br>
+ *
+ * <pre>
+ * #        Step1. Configure the secrets manager as config provider:
+ * config.providers=secretsmanager
+ * config.providers.secretsmanager.class=com.amazonaws.kafka.config.providers.SecretsMamagerConfigProvider
+ * # optional parameter for region:
+ * config.providers.secretsmanager.param.region=us-west-2
+ * # optional parameter, see more details below
+ * config.providers.secretsmanager.param.NotFoundStrategy=fail
+ *
+ * #        Step 2. Usage of AWS secrets manager as config provider:
+ * db.username=${secretsmanager:AmazonMSK_TestKafkaConfig:username}
+ * db.password=${secretsmanager:AmazonMSK_TestKafkaConfig:password}
+ * </pre>
+ *
+ * Note, this config provider implementation assumes secret values will be
+ * returned in Json format.
+ * Nested values aren't supported at this point.<br>
+ *
+ * SecretsManagerConfigProvider can be configured using parameters.<br>
+ * Format:<br>
+ * {@code config.providers.secretsmanager.param.<param_name> = <param_value>}<br>
+ *
+ * @param region           - defines a region to get a secret from.
+ * @param NotFoundStrategy - defines an action in case requested secret or a key
+ *                         in a value cannot be resolved. <br>
+ *                         <ul>
+ *                         Passible values are:
+ *                         <ul>
+ *                         {@code fail} - (Default) the code will throw an
+ *                         exception {@code ConfigNotFoundException}
+ *                         </ul>
+ *                         <ul>
+ *                         {@code ignore} - a value will remain with tokens
+ *                         without any change
+ *                         </ul>
+ *                         </ul>
+ *
+ *
+ *                         Expression usage:<br>
+ *                         <code>property_name=${secretsmanager:secret.id:secret.key}</code>
+ *
+ */
+public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final String EMPTY = "";
+
+    private SecretsManagerConfig config;
+    private String notFoundStrategy;
+
+    private SecretsManagerClientBuilder cBuilder;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.config = new SecretsManagerConfig(configs);
+        setCommonConfig(config);
+
+        this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
+
+        // set up a builder:
+        this.cBuilder = SecretsManagerClient.builder();
+        setClientCommonConfig(this.cBuilder);
+    }
+
+    /**
+     * Retrieves a secret from AWS Secrets Manager
+     *
+     * @param path the path in Parameters Store
+     * @return the configuration data
+     */
+    @Override
+    public ConfigData get(String path) {
+        return get(path, Collections.emptySet());
+    }
+
+    /**
+     * Retrieves secret's fields from a given secret.
+     *
+     * @param encodedPath AWS Secrets Manager
+     *                    <code> secret name or encoded ARN </code>
+     * @param keys        fields inside a given secret.
+     * @return the configuration data
+     */
+    @Override
+    public ConfigData get(String encodedPath, Set<String> keys) {
+        Map<String, String> data = new HashMap<>();
+        if (encodedPath == null || encodedPath.isEmpty()
+                || keys == null || keys.isEmpty()) {
+            // if no fields provided, just ignore this usage
+            return new ConfigData(data);
+        }
+
+        String path = URLDecoder.decode(encodedPath, StandardCharsets.UTF_8);
+        GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
+        Map<String, String> secretJson = null;
+        try {
+            SecretsManagerClient secretsClient = checkOrInitSecretManagerClient();
+            GetSecretValueResponse response = secretsClient.getSecretValue(request);
+            String value = response.secretString();
+
+            try {
+                secretJson = new ObjectMapper().readValue(value, new TypeReference<>() {
+                });
+            } catch (Exception e) {
+                log.error("Unexpected value of a secret's structure", e);
+                throw new ConfigException(path, value, "Unexpected value of a secret's structure");
+            }
+        } catch (ResourceNotFoundException e) {
+            log.info(
+                    "Secret id {} not found. Value will be handled according to a strategy defined by 'NotFoundStrategy'",
+                    path);
+            handleNotFoundByStrategy(data, path, null, e);
+        }
+
+        Long ttl = null;
+        for (String keyWithOptions : keys) {
+            String key = parseKey(keyWithOptions);
+            Map<String, String> options = parseKeyOptions(keyWithOptions);
+            ttl = getUpdatedTtl(ttl, options);
+
+            // secretJson can be null at this point only if there is a permissive strategy.
+            if (secretJson == null) {
+                data.put(key, EMPTY);
+                continue;
+            }
+            if (secretJson.containsKey(key)) {
+                data.put(keyWithOptions, secretJson.get(key));
+            } else {
+                log.info("Secret {} doesn't have a key {}.", path, key);
+                handleNotFoundByStrategy(data, path, key, null);
+            }
+        }
+
+        return ttl == null ? new ConfigData(data) : new ConfigData(data, ttl);
+    }
+
+    protected SecretsManagerClient checkOrInitSecretManagerClient() {
+        return cBuilder.build();
+    }
+
+    @Override
+    public void subscribe(String path, Set<String> keys, ConfigChangeCallback callback) {
+        log.info("Subscription is not implemented and will be ignored");
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    private void handleNotFoundByStrategy(Map<String, String> data, String path, String key, RuntimeException e) {
+        if (SecretsManagerConfig.NOT_FOUND_IGNORE.equals(this.notFoundStrategy)
+                && key != null && !key.isBlank()) {
+            data.put(key, "");
+        } else if (SecretsManagerConfig.NOT_FOUND_FAIL.equals(this.notFoundStrategy)) {
+            if (e != null) {
+                throw e;
+            } else {
+                throw new ConfigException(String.format("Secret undefined {}:{}", path, key));
+            }
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/kafka/config/providers/common/AwsServiceConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/common/AwsServiceConfigProvider.java
@@ -1,0 +1,149 @@
+
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.amazonaws.kafka.config.providers.common;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigChangeCallback;
+import org.apache.kafka.common.config.provider.ConfigProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
+import software.amazon.awssdk.regions.Region;
+
+public abstract class AwsServiceConfigProvider implements ConfigProvider {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private String region;
+    private String endpoint;
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    /**
+     * Set common AWS configuration parameters, like region, endpoint, etc...
+     * 
+     * @param config
+     */
+    public void setCommonConfig(AbstractConfig config) {
+
+        // default region from configuration. It can be null, empty or blank.
+        this.region = config.getString(CommonConfigUtils.REGION);
+        this.endpoint = config.getString(CommonConfigUtils.ENDPOINT);
+    }
+
+    @Override
+    public void subscribe(String path, Set<String> keys, ConfigChangeCallback callback) {
+        log.info("Subscription is not implemented and will be ignored");
+    }
+
+    public void close() throws IOException {
+    }
+
+    /**
+     * Set configuration that is common to most AWS Clients.
+     * 
+     * @param <T>
+     * @param cBuilder
+     * @return
+     */
+    protected <T extends AwsClientBuilder<?, ?>> T setClientCommonConfig(T cBuilder) {
+
+        if (this.region != null && !this.region.isBlank()) {
+            cBuilder.region(Region.of(this.region));
+        }
+
+        if (this.endpoint != null && !endpoint.isBlank())
+            try {
+                cBuilder.endpointOverride(new URI(this.endpoint));
+            } catch (URISyntaxException e) {
+                log.error("Invalid syntax, ", e);
+                throw new RuntimeException(e);
+            }
+
+        return cBuilder;
+    }
+
+    protected String parseKey(String keyWithOptions) {
+        if (keyWithOptions == null)
+            return keyWithOptions;
+
+        return keyWithOptions.split("\\?", 2)[0];
+    }
+
+    protected Map<String, String> parseKeyOptions(String keyWithOptions) {
+
+        Map<String, String> options = new LinkedHashMap<>();
+
+        if (keyWithOptions == null)
+            return options;
+
+        String[] parsed = keyWithOptions.split("\\?", 2);
+        if (parsed.length < 2)
+            return options;
+
+        Matcher m = Pattern.compile("(\\w+)=(.*?)(?=,\\w+=|$)").matcher(parsed[1]);
+        while (m.find()) {
+            options.put(m.group(1), m.group(2));
+        }
+
+        return options;
+    }
+
+    protected Long getUpdatedTtl(Long currentTtl, Map<String, String> options) {
+        if (options == null || options.isEmpty())
+            return currentTtl;
+
+        String newTtlStr = options.get("ttl");
+        if (newTtlStr == null)
+            return currentTtl;
+
+        try {
+            Long newTtl = Long.valueOf(newTtlStr);
+            return currentTtl == null || currentTtl > newTtl
+                    ? newTtl
+                    : currentTtl;
+        } catch (Exception e) {
+            log.warn("TTL value '{}' is not a number", newTtlStr, e);
+        }
+        return currentTtl;
+    }
+}

--- a/src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.amazonaws.kafka.config.providers.common;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+/**
+ * This utility class provides common functionality that can be reused for
+ * multiple Config Providers.
+ *
+ */
+public class CommonConfigUtils {
+
+    /** Common configuration parameters to be reused in multiple Config Providers */
+    public static final ConfigDef COMMON_CONFIG = getConfig();
+
+    public static final String REGION = "region";
+    private static final String REGION_DOC = "Specify region if needed. Default region is the same where connector is running";
+
+    public static final String ENDPOINT = "endpoint";
+    private static final String ENDPOINT_DOC = "(Optional) Specify an endpoint. Default endpoint will be used. "
+            + "If there is an endpoint for a service in a VPC, and it should be used instead of default one, "
+            + "this is the way to explicitly provide one.";
+
+    /**
+     * 
+     * @return common configuration
+     */
+    static ConfigDef getConfig() {
+        return new ConfigDef()
+                .define(
+                        REGION,
+                        ConfigDef.Type.STRING,
+                        "",
+                        ConfigDef.Importance.MEDIUM,
+                        REGION_DOC)
+                .define(
+                        ENDPOINT,
+                        ConfigDef.Type.STRING,
+                        "",
+                        ConfigDef.Importance.MEDIUM,
+                        ENDPOINT_DOC);
+    }
+}

--- a/src/main/java/com/couchbase/connect/kafka/config/source/CouchbaseSourceTaskConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/source/CouchbaseSourceTaskConfig.java
@@ -18,8 +18,6 @@ package com.couchbase.connect.kafka.config.source;
 
 import com.couchbase.client.dcp.util.PartitionSet;
 
-import java.util.List;
-
 public interface CouchbaseSourceTaskConfig extends CouchbaseSourceConfig {
   /**
    * Set of partitions for this task to watch for changes.

--- a/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -1,0 +1,1 @@
+com.amazonaws.kafka.config.providers.SecretsManagerConfigProvider

--- a/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
@@ -1,0 +1,40 @@
+package com.amazonaws.kafka.config.providers;
+
+import org.mockito.stubbing.Answer;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MockedSecretsManagerConfigProvider extends SecretsManagerConfigProvider {
+    @Override
+    protected SecretsManagerClient checkOrInitSecretManagerClient() {
+        SecretsManagerClient secretsClient = mock(SecretsManagerClient.class);
+        when(secretsClient.getSecretValue(request("AmazonMSK_TestKafkaConfig"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")
+        );
+        when(secretsClient.getSecretValue(request("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John2\", \"password\":\"Password567\"}")
+        );
+        when(secretsClient.getSecretValue(request("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret%3A"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John3\", \"password\":\"Password321\"}")
+        );
+        when(secretsClient.getSecretValue(request("AmazonMSK_TestTTL"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")
+        );
+        when(secretsClient.getSecretValue(request("notFound"))).thenThrow(ResourceNotFoundException.class);
+        return secretsClient;
+    }
+
+    private GetSecretValueRequest request(String path) {
+        return GetSecretValueRequest.builder().secretId(path).build();
+    }
+
+    private GetSecretValueResponse response(String value) {
+        return GetSecretValueResponse.builder().secretString(value).build();
+    }
+}

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.amazonaws.kafka.config.providers;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.codec.Charsets;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+public class SecretsManagerConfigProviderTest {
+
+    Map<String, Object> props;
+    @BeforeEach
+    public void setup() {
+        props = new HashMap<>();
+        props.put("config.providers", "secretsmanager");
+        props.put("config.providers.secretsmanager.class", "com.amazonaws.kafka.config.providers.MockedSecretsManagerConfigProvider");
+        props.put("config.providers.secretsmanager.param.region", "us-west-2");
+        props.put("config.providers.secretsmanager.param.NotFoundStrategy", "fail");
+    }
+    
+    @Test
+    public void testExistingKeys() {
+        props.put("username", "${secretsmanager:AmazonMSK_TestKafkaConfig:username}");
+        props.put("password", "${secretsmanager:AmazonMSK_TestKafkaConfig:password}");
+
+        CustomConfig testConfig = new CustomConfig(props);
+
+        assertEquals("John", testConfig.getString("username"));
+        assertEquals("Password123", testConfig.getString("password"));
+    }
+
+    @Test
+    public void testExistingKeysViaArn() {
+        String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret", StandardCharsets.UTF_8);
+        props.put("username", "${secretsmanager:" + arn + ":username}");
+        props.put("password", "${secretsmanager:" + arn + ":password}");
+
+        CustomConfig testConfig = new CustomConfig(props);
+
+        assertEquals("John2", testConfig.getString("username"));
+        assertEquals("Password567", testConfig.getString("password"));
+    }
+
+    @Test
+    public void testExistingKeysViaArnWithEncodedValue() {
+        String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret%3A", StandardCharsets.UTF_8);
+        props.put("username", "${secretsmanager:" + arn + ":username}");
+        props.put("password", "${secretsmanager:" + arn + ":password}");
+
+        CustomConfig testConfig = new CustomConfig(props);
+
+        assertEquals("John3", testConfig.getString("username"));
+        assertEquals("Password321", testConfig.getString("password"));
+    }
+
+    @Test
+    public void testExistingKeysViaHandEncodedArn() {
+        String arn = "arn%3Aaws%3Asecretsmanager%3Aap-southeast-2%3A123456789%3Asecret%3AAmazonMSK_my_service%2Fmy_secret";
+        props.put("username", "${secretsmanager:" + arn + ":username}");
+        props.put("password", "${secretsmanager:" + arn + ":password}");
+
+        CustomConfig testConfig = new CustomConfig(props);
+
+        assertEquals("John2", testConfig.getString("username"));
+        assertEquals("Password567", testConfig.getString("password"));
+    }
+
+    @Test
+    public void testTtl() {
+        props.put("username", "${secretsmanager:AmazonMSK_TestKafkaConfig:username?ttl=60000}");
+        props.put("password", "${secretsmanager:AmazonMSK_TestKafkaConfig:password}");
+        
+        CustomConfig testConfig = new CustomConfig(props);
+        
+        assertEquals("John", testConfig.getString("username"));
+        assertEquals("Password123", testConfig.getString("password"));
+    }
+
+    @Test
+    public void testNonExistingSecret() {
+        props.put("notFound", "${secretsmanager:notFound:noKey}");
+        assertThrows(ResourceNotFoundException.class, () ->new CustomConfig(props));
+    }
+    
+    @Test
+    public void testNonExistingKey() {
+        props.put("notFound", "${secretsmanager:AmazonMSK_TestKafkaConfig:noKey}");
+        assertThrows(ConfigException.class, () ->new CustomConfig(props));
+    }
+    
+    static class CustomConfig extends AbstractConfig {
+        final static String DEFAULT_DOC = "Default Doc";
+        final static ConfigDef CONFIG = new ConfigDef()
+                .define("username", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
+                .define("password", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
+                ;
+        public CustomConfig(Map<?, ?> originals) {
+            super(CONFIG, originals);
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request includes several changes to the `pom.xml` file and introduces new classes for AWS Secrets Manager configuration in the Java codebase. The most important changes are the addition of new dependencies, the creation of new configuration classes, and the modification of existing plugin configurations.

### Dependency and Configuration Updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L71-R71): Added new dependencies for AWS SDK modules (`iam`, `secretsmanager`, `ssm`) and changed the Java compatibility version from 17 to 11. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L71-R71) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R186-R197)

### New Classes for AWS Secrets Manager:

* [`src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfig.java`](diffhunk://#diff-dd291954943a0cbcf929e2dff5c90e1b7ae336a6aed7cfddbaa4710afa0bef36R1-R53): Introduced a new configuration class for AWS Secrets Manager, defining parameters like `NotFoundStrategy`.
* [`src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java`](diffhunk://#diff-5093aaab26ebe2090cf437fa5e529dde237b24845e1e4d3b22fbe0e6f6878194R1-R213): Added a new config provider class for AWS Secrets Manager, implementing methods to retrieve and handle secrets.
* [`src/main/java/com/amazonaws/kafka/config/providers/common/AwsServiceConfigProvider.java`](diffhunk://#diff-1632e5020ca97228a716d11e7883f6ce3f09519cb2925f3be1e59523d1ef70d7R1-R149): Created a common base class for AWS service config providers, including methods for setting common AWS configuration parameters.
* [`src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java`](diffhunk://#diff-5367000f034f1adbaa6365ac252973cc07d2984ce469fc2684d564b3a1edef4cR1-R58): Added a utility class to provide common configuration parameters for multiple config providers.

### Plugin Configuration Changes:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L225-R245): Commented out and disabled certain Maven plugins (`exec-maven-plugin`, `maven-source-plugin`) and added new configuration options (`doclint`, `source`). [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L225-R245) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L252-R264) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R307-R310)

### Service Provider Configuration:

* [`src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider`](diffhunk://#diff-32b087aa52c8cd91927153ef5abd4f368fbace99526bd8ab4d635eacda9351e6R1): Registered the new `SecretsManagerConfigProvider` as a service provider.