### PR TITLE
Add sharespace filtering to RegexKeyFilter and corresponding tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/src/main/java/com/netdocuments/connect/kafka/filter/RegexKeyFilter.java
+++ b/src/main/java/com/netdocuments/connect/kafka/filter/RegexKeyFilter.java
@@ -16,14 +16,17 @@ public class RegexKeyFilter implements Filter {
 
     private static final String REGEX_CONFIG = "couchbase.event.filter.regex";
     private static final String REGEX_CASE_INSENSITIVE_CONFIG = "couchbase.event.filter.regex.case_insensitive";
+    private static final String SHARESPACE_CONFIG = "couchbase.event.filter.sharespace.filter";
 
     private Pattern pattern;
+    private boolean filterSharespaces;
 
     @Override
     public void init(Map<String, String> props) {
         AbstractConfig config = new AbstractConfig(getConfigDef(), props);
         String regex = config.getString(REGEX_CONFIG);
         boolean caseInsensitive = config.getBoolean(REGEX_CASE_INSENSITIVE_CONFIG);
+        filterSharespaces = config.getBoolean(SHARESPACE_CONFIG);
 
         if (regex == null || regex.isEmpty()) {
             throw new ConfigException("RegexKeyFilter requires a non-empty regex");
@@ -42,6 +45,10 @@ public class RegexKeyFilter implements Filter {
     @Override
     public boolean pass(DocumentEvent event) {
         String key = event.key();
+        if (filterSharespaces && isShareSpace(key)) {
+            LOGGER.debug("Key '{}' is a sharespace, skipping", key);
+            return false;
+        }
         boolean matches = pattern.matcher(key).matches();
         LOGGER.debug("Key '{}' {} regex filter", key, matches ? "passed" : "did not pass");
         return matches;
@@ -52,6 +59,65 @@ public class RegexKeyFilter implements Filter {
                 .define(REGEX_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
                         "Regular expression to match document keys")
                 .define(REGEX_CASE_INSENSITIVE_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
-                        "Whether the regex matching should be case-insensitive");
+                        "Whether the regex matching should be case-insensitive")
+                .define(SHARESPACE_CONFIG, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM,
+                        "Whether to filter out sharespace events");
+    }
+
+    /**
+     * Fetches the envelope type of the given url. Returns true only if it's a
+     * ShareSpace. A sharespace URL can be spotted by looking at the first and
+     * second character after the last slash. It is not a sharespace if the first
+     * character is a ~ or the first character is a ^ and the second character is
+     * not a D. Any other case it is a sharespace.
+     *
+     * @param url The URL to analyze.
+     * @return Returns true if the envelope type of the given url is a ShareSpace,
+     *         false otherwise.
+     */
+    static boolean isShareSpace(String url) {
+        url = modifyKey(url);
+        if (url != null && !url.isEmpty()) {
+            if (url.indexOf(':') >= 0) {
+                url = url.replace(':', '/'); // transform REST API ID into an envUrl
+            }
+            int pos = url.lastIndexOf('/');
+            if (pos >= 0 && pos + 2 <= url.length()) {
+                char c1 = url.charAt(pos + 1);
+                switch (c1) {
+                    case '~':
+                        return false;
+                    case '^':
+                        if (pos + 2 < url.length()) {
+                            char c2 = Character.toLowerCase(url.charAt(pos + 2));
+                            return c2 == 'd'; // ShareSpace (NetBinder, former NetEnvelope)
+                        }
+                        return false;
+                }
+            }
+        }
+        return true; // Default case is still ShareSpace (NetBinder)
+    }
+
+    /**
+     * Modifies the original key by adding '/' after each of the next four letters
+     * after the existing '/'. Keys take the form of:
+     * MDucot5/qbti~240924115010829
+     * HDucot5/qbti~240924115010829
+     *
+     * @param originalKey The original document key
+     * @return The modified key with additional '/' characters
+     */
+    static String modifyKey(String originalKey) {
+        int firstSlashIndex = originalKey.indexOf('/');
+        if (firstSlashIndex == -1 || firstSlashIndex + 5 > originalKey.length()) {
+            return originalKey;
+        }
+
+        StringBuilder modifiedKey = new StringBuilder(originalKey);
+        for (int i = 1; i <= 4; i++) {
+            modifiedKey.insert(firstSlashIndex + i * 2, '/');
+        }
+        return modifiedKey.toString();
     }
 }

--- a/src/test/java/com/netdocuments/connect/kafka/filter/RegexKeyFilterTest.java
+++ b/src/test/java/com/netdocuments/connect/kafka/filter/RegexKeyFilterTest.java
@@ -1,0 +1,156 @@
+package com.netdocuments.connect.kafka.filter;
+
+import com.couchbase.connect.kafka.handler.source.DocumentEvent;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RegexKeyFilterTest {
+
+    @Test
+    void testInitWithValidRegex() {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", "test.*");
+        props.put("couchbase.event.filter.regex.case_insensitive", "true");
+
+        assertDoesNotThrow(() -> filter.init(props));
+    }
+
+    @Test
+    void testInitWithEmptyRegex() {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", "");
+
+        assertThrows(ConfigException.class, () -> filter.init(props));
+    }
+
+    @Test
+    void testInitWithInvalidRegex() {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", "[invalid");
+
+        assertThrows(ConfigException.class, () -> filter.init(props));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "test123", "TEST456", "testABC" })
+    void testPassWithMatchingKeysAndSharespaceFilterDisabled(String key) {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", "test.*");
+        props.put("couchbase.event.filter.regex.case_insensitive", "true");
+        props.put("couchbase.event.filter.sharespace.filter", "false");
+        filter.init(props);
+
+        DocumentEvent event = mock(DocumentEvent.class);
+        when(event.key()).thenReturn(key);
+
+        assertTrue(filter.pass(event));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "abc123", "123test", "xyzTEST" })
+    void testPassWithNonMatchingKeysAndSharespaceFilterDisabled(String key) {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", "test.*");
+        props.put("couchbase.event.filter.regex.case_insensitive", "true");
+        props.put("couchbase.event.filter.sharespace.filter", "false");
+        filter.init(props);
+
+        DocumentEvent event = mock(DocumentEvent.class);
+        when(event.key()).thenReturn(key);
+
+        assertFalse(filter.pass(event));
+    }
+
+    @Test
+    void testPassWithSharespaceFilterEnabled() {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", ".*");
+        props.put("couchbase.event.filter.regex.case_insensitive", "true");
+        props.put("couchbase.event.filter.sharespace.filter", "true");
+        filter.init(props);
+
+        DocumentEvent shareSpaceEvent = mock(DocumentEvent.class);
+        when(shareSpaceEvent.key()).thenReturn("MDucot5/q/b/t/i/^D240924115010829");
+        assertFalse(filter.pass(shareSpaceEvent));
+
+        DocumentEvent nonShareSpaceEvent = mock(DocumentEvent.class);
+        when(nonShareSpaceEvent.key()).thenReturn("MDucot5/q/b/t/i/~240924115010829");
+        assertTrue(filter.pass(nonShareSpaceEvent));
+    }
+
+    @Test
+    void testPassWithCaseSensitiveRegexAndSharespaceFilter() {
+        RegexKeyFilter filter = new RegexKeyFilter();
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.event.filter.regex", ".*test.*");
+        props.put("couchbase.event.filter.regex.case_insensitive", "false");
+        props.put("couchbase.event.filter.sharespace.filter", "true");
+        filter.init(props);
+
+        DocumentEvent event1 = mock(DocumentEvent.class);
+        when(event1.key()).thenReturn("MDucot5/q/b/t/i/~test123");
+        assertTrue(filter.pass(event1));
+
+        DocumentEvent event2 = mock(DocumentEvent.class);
+        when(event2.key()).thenReturn("TEST123");
+        assertFalse(filter.pass(event2));
+
+        DocumentEvent shareSpaceEvent = mock(DocumentEvent.class);
+        when(shareSpaceEvent.key()).thenReturn("MDucot5/q/b/t/i/^D240924115010829");
+        assertFalse(filter.pass(shareSpaceEvent));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "MDucot5/qbti~240924115010829",
+            "HDucot5/qbti~240924115010829",
+            "HDucot5/qbti^f240924115010829",
+            "HDucot5/qbti^w240924115010829",
+            "HDucot5/qbti^c240924115010829",
+            "HDucot5/qbti^b240924115010829",
+            "HDucot5/qbti^r240924115010829"
+    })
+    void testIsShareSpaceWithInvalidKeys(String key) {
+        assertFalse(RegexKeyFilter.isShareSpace(key), '"' + key + '"');
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "MDucot5/qbti^D240924115010829",
+            "sharespacename",
+            "something strange",
+            "1",
+            "MDucot5/qbtiNB240924115010829",
+    })
+    void testIsShareSpaceWithValidKeys(String key) {
+        assertTrue(RegexKeyFilter.isShareSpace(key), '"' + key + '"');
+    }
+
+    @Test
+    void testModifyKey() {
+        String originalKey = "MDucot5/qbti~240924115010829";
+        String expectedModifiedKey = "MDucot5/q/b/t/i/~240924115010829";
+        assertEquals(expectedModifiedKey, RegexKeyFilter.modifyKey(originalKey));
+    }
+
+    @Test
+    void testModifyKeyWithShortKey() {
+        String shortKey = "short";
+        assertEquals(shortKey, RegexKeyFilter.modifyKey(shortKey));
+    }
+}


### PR DESCRIPTION
Implement sharespace filtering in RegexKeyFilter to allow selective processing of events based on sharespace criteria. Include comprehensive tests to validate the new functionality.