### PR TITLE
Merge upstream changes

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -4,8 +4,7 @@
 
 If you come across a bug or find something unintuitive, let us know and we’ll work to fix it in an upcoming release.
 
-To file a bug report or feature request, go to the https://issues.couchbase.com[Couchbase Jira site].
-If this is your first visit, request an account using the "Jira Administrators" link below the Login form.
+To file a bug report or feature request, go to the *Issues* tab of this GitHub repository.
 
 When filing a bug report, please include:
 

--- a/docs/modules/ROOT/pages/generated-sink-config-reference.adoc
+++ b/docs/modules/ROOT/pages/generated-sink-config-reference.adoc
@@ -226,6 +226,27 @@ Defaults to an empty map, with all documents going to the collection specified b
 * Valid Values: topic1=scope.collection,topic2=other-bucket.scope.collection,... If a bucket component contains a dot, escape it by enclosing it in backticks.
 * Importance: medium
 
+[[couchbase.topic.to.document.id]]
+=== `couchbase.topic.to.document.id`
+
+A map of per-topic overrides for the `couchbase.document.id` configuration property.
+
+Topic and document ID format are joined by an equals sign.
+Map entries are delimited by commas.
+
+For example, if documents from topic "topic1" should be assigned document IDs that match their "id" field, and documents from topic "topic2" should be assigned documents IDs that match their "identifier" field, you would write: "topic1=${/id},topic2=${/identifier}".
+
+Defaults to an empty map, which means the value of the `couchbase.document.id` configuration property is applied to documents from all topics.
+
+UNCOMMITTED; this feature may change in a patch release without notice.
+
+* Since: 4.2.4
+
+* Type: list
+* Default: `""`
+* Valid Values: topic1=${/id},topic2=${/some/other/path},...
+* Importance: medium
+
 [[couchbase.sink.handler]]
 === `couchbase.sink.handler`
 

--- a/docs/modules/ROOT/pages/generated-source-config-reference.adoc
+++ b/docs/modules/ROOT/pages/generated-source-config-reference.adoc
@@ -272,6 +272,27 @@ To reduce disk usage, configure this topic to use small segments and the lowest 
 * Default: `""`
 * Importance: medium
 
+[[couchbase.initial.offset.topic]]
+=== `couchbase.initial.offset.topic`
+
+If `couchbase.stream.from` is `SAVED_OFFSET_OR_NOW`, and this property is non-blank, on startup the connector publishes to the named topic one tiny synthetic record for each source partition that does not yet have a saved offset.
+
+This lets the connector initialize the missing source offsets to "now" (the current state of Couchbase).
+
+The synthetic records have a value of null, and the same key: `__COUCHBASE_INITIAL_OFFSET_TOMBSTONE__a54ee32b-4a7e-4d98-aa36-45d8417e942a`.
+
+Consumers of this topic must ignore (or tolerate) these records.
+
+If you specify a value for `couchbase.black.hole.topic`, specify the same value here.
+
+UNCOMMITTED; this feature may change in a patch release without notice.
+
+* Since: 4.2.4
+
+* Type: string
+* Default: `""`
+* Importance: medium
+
 [[couchbase.batch.size.max]]
 === `couchbase.batch.size.max`
 

--- a/docs/modules/ROOT/pages/generated-source-config-reference.adoc
+++ b/docs/modules/ROOT/pages/generated-source-config-reference.adoc
@@ -248,8 +248,10 @@ See that property's documentation for details.
 The class name of the event filter to use.
 The event filter determines whether a database change event is ignored.
 
-When using a non-default filter, consider also configuring `couchbase.black.hole.topic`.
-See that property's documentation for details.
+As of version 4.2.4, the default filter ignores events from the Couchbase `_system` scope.
+If you are interested in those events too, set this property to `com.couchbase.connect.kafka.filter.AllPassIncludingSystemFilter`.
+
+See also `couchbase.black.hole.topic`.
 
 * Type: class
 * Default: `com.couchbase.connect.kafka.filter.AllPassFilter`

--- a/examples/custom-extensions/pom.xml
+++ b/examples/custom-extensions/pom.xml
@@ -30,7 +30,7 @@
         <java-compat.version>1.8</java-compat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kafka-connect-couchbase.version>4.2.3</kafka-connect-couchbase.version>
+        <kafka-connect-couchbase.version>4.2.4</kafka-connect-couchbase.version>
         <kafka.version>2.8.2</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
     </properties>

--- a/examples/custom-extensions/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/examples/custom-extensions/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,1 @@
+com.couchbase.connect.kafka.example.CustomTransform

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
     <properties>
         <java-compat.version>1.8</java-compat.version>
         <kafka.version>2.8.2</kafka.version>
-        <dcp-client.version>0.51.0</dcp-client.version>
-        <java-client.version>3.7.1</java-client.version>
+        <dcp-client.version>0.52.0</dcp-client.version>
+        <java-client.version>3.7.4</java-client.version>
         <runtime.javadoc.version>0.13.0</runtime.javadoc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.3</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.couchbase.client</groupId>
     <artifactId>kafka-connect-couchbase</artifactId>
     <packaging>jar</packaging>
-    <version>4.2.4-SNAPSHOT</version>
+    <version>4.2.4</version>
     <name>Kafka Connector for Couchbase</name>
     <organization>
         <name>Couchbase, Inc.</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.couchbase.client</groupId>
     <artifactId>kafka-connect-couchbase</artifactId>
     <packaging>jar</packaging>
-    <version>4.2.4</version>
+    <version>4.2.5-SNAPSHOT</version>
     <name>Kafka Connector for Couchbase</name>
     <organization>
         <name>Couchbase, Inc.</name>

--- a/src/main/java/com/couchbase/connect/kafka/SourceTaskLifecycle.java
+++ b/src/main/java/com/couchbase/connect/kafka/SourceTaskLifecycle.java
@@ -38,6 +38,7 @@ public class SourceTaskLifecycle {
     TASK_STARTED,
     TASK_STOPPED,
     SOURCE_OFFSETS_READ,
+    MISSING_SOURCE_OFFSETS_SET_TO_NOW,
     OFFSET_COMMIT_HOOK,
   }
 
@@ -68,6 +69,12 @@ public class SourceTaskLifecycle {
     details.put("partitionsWithNoSavedOffset", partitionsWithoutSavedOffsets.format());
     details.put("sourceOffsets", new TreeMap<>(sourceOffsets));
     logMilestone(Milestone.SOURCE_OFFSETS_READ, details);
+  }
+
+  public void logMissingSourceOffsetsSetToNow(PartitionSet partitionsSetToNow) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("partitionsSetToNow", partitionsSetToNow.format());
+    logMilestone(Milestone.MISSING_SOURCE_OFFSETS_SET_TO_NOW, details);
   }
 
   public void logTaskStopped() {

--- a/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
@@ -16,6 +16,7 @@
 
 package com.couchbase.connect.kafka.config.sink;
 
+import com.couchbase.client.core.annotation.Stability;
 import com.couchbase.connect.kafka.handler.sink.N1qlSinkHandler;
 import com.couchbase.connect.kafka.handler.sink.SinkHandler;
 import com.couchbase.connect.kafka.handler.sink.SubDocumentSinkHandler;
@@ -71,6 +72,34 @@ public interface SinkBehaviorConfig {
    */
   @Default
   List<String> topicToCollection();
+
+  /**
+   * A map of per-topic overrides for the `couchbase.document.id` configuration property.
+   * <p>
+   * Topic and document ID format are joined by an equals sign.
+   * Map entries are delimited by commas.
+   * <p>
+   * For example, if documents from topic "topic1" should be assigned document IDs that match their "id" field,
+   * and documents from topic "topic2" should be assigned documents IDs that match their "identifier" field,
+   * you would write:
+   * "topic1=${/id},topic2=${/identifier}".
+   * <p>
+   * Defaults to an empty map, which means the value of the `couchbase.document.id`
+   * configuration property is applied to documents from all topics.
+   *
+   * @since 4.2.4
+   */
+  @Stability.Volatile
+  @Default
+  List<String> topicToDocumentId();
+
+  @SuppressWarnings("unused")
+  static ConfigDef.Validator topicToDocumentIdValidator() {
+    return validate(
+        (List<String> value) -> TopicMap.parseTopicToDocumentId(value, true),
+        "topic1=${/id},topic2=${/some/other/path},..."
+    );
+  }
 
   @SuppressWarnings("unused")
   static ConfigDef.Validator topicToCollectionValidator() {

--- a/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/sink/SinkBehaviorConfig.java
@@ -89,7 +89,7 @@ public interface SinkBehaviorConfig {
    *
    * @since 4.2.4
    */
-  @Stability.Volatile
+  @Stability.Uncommitted
   @Default
   List<String> topicToDocumentId();
 

--- a/src/main/java/com/couchbase/connect/kafka/config/source/SourceBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/source/SourceBehaviorConfig.java
@@ -16,6 +16,7 @@
 
 package com.couchbase.connect.kafka.config.source;
 
+import com.couchbase.client.core.annotation.Stability;
 import com.couchbase.connect.kafka.StreamFrom;
 import com.couchbase.connect.kafka.filter.Filter;
 import com.couchbase.connect.kafka.handler.source.SourceHandler;
@@ -110,6 +111,27 @@ public interface SourceBehaviorConfig {
    */
   @Default
   String blackHoleTopic();
+
+  /**
+   * If `couchbase.stream.from` is `SAVED_OFFSET_OR_NOW`, and this property is non-blank,
+   * on startup the connector publishes to the named topic one tiny synthetic record
+   * for each source partition that does not yet have a saved offset.
+   * <p>
+   * This lets the connector initialize the missing source offsets to "now" (the current
+   * state of Couchbase).
+   * <p>
+   * The synthetic records have a value of null, and the same key:
+   * `__COUCHBASE_INITIAL_OFFSET_TOMBSTONE__a54ee32b-4a7e-4d98-aa36-45d8417e942a`.
+   * <p>
+   * Consumers of this topic must ignore (or tolerate) these records.
+   * <p>
+   * If you specify a value for `couchbase.black.hole.topic`, specify the same value here.
+   *
+   * @since 4.2.4
+   */
+  @Stability.Uncommitted
+  @Default
+  String initialOffsetTopic();
 
   /**
    * Controls maximum size of the batch for writing into topic.

--- a/src/main/java/com/couchbase/connect/kafka/config/source/SourceBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/source/SourceBehaviorConfig.java
@@ -86,9 +86,12 @@ public interface SourceBehaviorConfig {
    * The class name of the event filter to use.
    * The event filter determines whether a database change event is ignored.
    * <p>
-   * When using a non-default filter,
-   * consider also configuring `couchbase.black.hole.topic`.
-   * See that property's documentation for details.
+   * As of version 4.2.4, the default filter ignores
+   * events from the Couchbase `_system` scope.
+   * If you are interested in those events too, set this property to
+   * `com.couchbase.connect.kafka.filter.AllPassIncludingSystemFilter`.
+   * <p>
+   * See also `couchbase.black.hole.topic`.
    */
   @Default("com.couchbase.connect.kafka.filter.AllPassFilter")
   Class<? extends Filter> eventFilter();

--- a/src/main/java/com/couchbase/connect/kafka/filter/AllPassIncludingSystemFilter.java
+++ b/src/main/java/com/couchbase/connect/kafka/filter/AllPassIncludingSystemFilter.java
@@ -19,22 +19,11 @@ package com.couchbase.connect.kafka.filter;
 import com.couchbase.connect.kafka.handler.source.DocumentEvent;
 
 /**
- * Allows publication of any event, except for events in Couchbase system scopes.
- * <p>
- * A system scope is any scope whose name start with percent or underscore,
- * except for the default scope (whose name is "_default").
- *
- * @see AllPassIncludingSystemFilter
+ * Allows publication of any event, including events in system scopes.
  */
-public class AllPassFilter implements Filter {
-
+public class AllPassIncludingSystemFilter implements Filter {
   @Override
   public boolean pass(final DocumentEvent event) {
-    return !isSystemScope(event);
-  }
-
-  private static boolean isSystemScope(DocumentEvent event) {
-    String scopeName = event.collectionMetadata().scopeName();
-    return scopeName.startsWith("%") || (scopeName.startsWith("_") && !scopeName.equals("_default"));
+    return true;
   }
 }

--- a/src/main/java/com/couchbase/connect/kafka/util/TopicMap.java
+++ b/src/main/java/com/couchbase/connect/kafka/util/TopicMap.java
@@ -30,6 +30,13 @@ public class TopicMap {
     throw new AssertionError("not instantiable");
   }
 
+  public static Map<String, DocumentIdExtractor> parseTopicToDocumentId(
+      List<String> topicToDocumentIdFormat,
+      boolean removeDocumentId
+  ) {
+    return mapValues(parseCommon(topicToDocumentIdFormat), docIdFormat -> new DocumentIdExtractor(docIdFormat, removeDocumentId));
+  }
+
   public static Map<String, Keyspace> parseTopicToCollection(
       List<String> topicToCollection,
       @Nullable String defaultBucket
@@ -46,7 +53,7 @@ public class TopicMap {
     for (String entry : map) {
       String[] components = entry.split("=", -1);
       if (components.length != 2) {
-        throw new IllegalArgumentException("Bad entry: '" + entry + "'. Expected exactly one equals (=) character separating topic and collection.");
+        throw new IllegalArgumentException("Bad entry: '" + entry + "'. Expected exactly one equals (=) character separating key and value.");
       }
       result.put(components[0], components[1]);
     }

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.sink.SinkConnector
@@ -1,0 +1,1 @@
+com.couchbase.connect.kafka.CouchbaseSinkConnector

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,0 +1,1 @@
+com.couchbase.connect.kafka.CouchbaseSourceConnector

--- a/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
+++ b/src/main/resources/META-INF/services/org.apache.kafka.connect.transforms.Transformation
@@ -1,0 +1,2 @@
+com.couchbase.connect.kafka.transform.DropIfNullValue
+com.couchbase.connect.kafka.transform.DeserializeJson


### PR DESCRIPTION
This pull request includes several updates to documentation, configuration, and code related to Couchbase Kafka Connector. The most important changes include updates to documentation for new configuration properties, version upgrades, and enhancements to the `CouchbaseReader` and `CouchbaseSinkTask` classes.

### Documentation Updates:
* Updated the bug report instructions to use the GitHub Issues tab instead of the Couchbase Jira site.
* Added documentation for the new `couchbase.topic.to.document.id` configuration property in the sink configuration reference.
* Updated the source configuration reference to include the new `couchbase.initial.offset.topic` property and details about the default event filter behavior. [[1]](diffhunk://#diff-1060e8a75d6877cbcddd52aaa26dcb325c0e16fc09a0a1d2ac5ea55538fbccd7L251-R254) [[2]](diffhunk://#diff-1060e8a75d6877cbcddd52aaa26dcb325c0e16fc09a0a1d2ac5ea55538fbccd7R277-R297)

### Version Upgrades:
* Upgraded `kafka-connect-couchbase` version to 4.2.4 in `examples/custom-extensions/pom.xml`.
* Updated the main `pom.xml` to version 4.2.5-SNAPSHOT and upgraded dependencies for `dcp-client` and `java-client`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L26-R26) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L73-R74)

### Code Enhancements:
* Added a new `INITIAL_OFFSET_TOMBSTONE_KEY` and logic to emit synthetic initial offsets in `CouchbaseReader`. [[1]](diffhunk://#diff-2d08f8dd9102ad765ffabb7fb52f59cc0460c89356c3466178761dbc61d5f3e5R70-R79) [[2]](diffhunk://#diff-2d08f8dd9102ad765ffabb7fb52f59cc0460c89356c3466178761dbc61d5f3e5R236-R284)
* Enhanced `CouchbaseSinkTask` to support per-topic document ID extraction. [[1]](diffhunk://#diff-4f8c0f093d4dcdcc3fb58e6d2ce9fe84e686f3c382c64c705e7776324c2f3e06L74-R75) [[2]](diffhunk://#diff-4f8c0f093d4dcdcc3fb58e6d2ce9fe84e686f3c382c64c705e7776324c2f3e06R251)
* Updated `CouchbaseSourceTask` to handle the new `initialOffsetTopic` configuration and log synthetic offset events. [[1]](diffhunk://#diff-e3f0b5e0ce8fb9b2152e5313995255aeb45a77263e1f69720310b14f807b72c6R105) [[2]](diffhunk://#diff-e3f0b5e0ce8fb9b2152e5313995255aeb45a77263e1f69720310b14f807b72c6R268-R272) [[3]](diffhunk://#diff-e3f0b5e0ce8fb9b2152e5313995255aeb45a77263e1f69720310b14f807b72c6R287-R293)

These changes improve the flexibility and functionality of the Couchbase Kafka Connector, making it easier to configure and use in various scenarios.