### PR TITLE
Upload partial objects to S3

### DIFF
--- a/src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java
+++ b/src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java
@@ -309,4 +309,42 @@ class NDSourceHandlerTest {
         verify(mockBuilder, never()).value(any(), any());
         verify(mockS3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
+
+    @Test
+    void testGenerateS3Key() {
+        // Arrange
+        String originalKey = "MDucot5/qbti~240924115010829";
+        long revisionSeqno = 123L;
+        byte[] content = "{\"documents\":{\"1\":{\"docProps\":{\"id\":\"doc123\"}}}}".getBytes();
+
+        when(mockEvent.key()).thenReturn(originalKey);
+        when(mockEvent.revisionSeqno()).thenReturn(revisionSeqno);
+        when(mockEvent.content()).thenReturn(content);
+
+        // Act
+        String result = handler.generateS3Key(mockEvent);
+
+        // Assert
+        String expectedKey = "MDucot5/q/b/t/i/~240924115010829/doc123/123.json";
+        assertEquals(expectedKey, result);
+    }
+
+    @Test
+    void testGenerateS3KeyForNonDocumentEvent() {
+        // Arrange
+        String originalKey = "shortKey";
+        long revisionSeqno = 456L;
+        byte[] content = "{}".getBytes();
+
+        when(mockEvent.key()).thenReturn(originalKey);
+        when(mockEvent.revisionSeqno()).thenReturn(revisionSeqno);
+        when(mockEvent.content()).thenReturn(content);
+
+        // Act
+        String result = handler.generateS3Key(mockEvent);
+
+        // Assert
+        String expectedKey = "directory/shortKey/456.json";
+        assertEquals(expectedKey, result);
+    }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `NDSourceHandler` class and its corresponding test class, `NDSourceHandlerTest`. The changes primarily focus on enhancing the handling of document events, particularly with respect to S3 key generation and S3 uploads. Additionally, several new unit tests have been added to ensure the robustness of these changes.

Enhancements to `NDSourceHandler`:

* Modified the `generateS3Key` method to handle non-document events by calling a new method `generateS3KeyForDirectory` when appropriate. [[1]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aL276-R283) [[2]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aR294-R298)
* Added a new method `generateS3KeyForDirectory` to generate S3 keys for directory-based storage of document events.
* Updated the `handleSpecificFieldsExtractionMutation` method to upload large documents to S3 and update the builder value accordingly.

Unit tests for `NDSourceHandler`:

* Added several new unit tests in `NDSourceHandlerTest` to verify the functionality of `generateS3Key`, `generateS3KeyForDirectory`, and `handleSpecificFieldsExtractionMutation`.
* Initialized mock objects and set up the test environment in the `NDSourceHandlerTest` class to support the new tests. [[1]](diffhunk://#diff-85ef77ccd5bcc7c7cfe9fae8952ed6201653bfed6be73274b18057205cb1bd8fR43-R54) [[2]](diffhunk://#diff-85ef77ccd5bcc7c7cfe9fae8952ed6201653bfed6be73274b18057205cb1bd8fR25-R30)