### PR TITLE
Fixed test

### DIFF
--- a/src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java
+++ b/src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java
@@ -119,7 +119,7 @@ class NDSourceHandlerTest {
 
         PutObjectRequest putObjectRequest = requestCaptor.getValue();
         assertEquals("test-bucket", putObjectRequest.bucket());
-        assertTrue(putObjectRequest.key().startsWith("test-key/"));
+        assertTrue(putObjectRequest.key().startsWith("directory/test-key/"));
         assertTrue(putObjectRequest.key().endsWith(".json"));
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `NDSourceHandlerTest.java` file. The change modifies the assertion for the S3 object key to ensure it starts with the correct directory prefix.

Testing improvements:

* [`src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java`](diffhunk://#diff-85ef77ccd5bcc7c7cfe9fae8952ed6201653bfed6be73274b18057205cb1bd8fL122-R122): Updated the `testHandleMutationAboveS3Threshold` method to assert that the S3 object key starts with "directory/test-key/" instead of "test-key/".