### PR TITLE
AB#343791 Added ability to filter based on attribute

### DIFF
--- a/examples/json-producer/pom.xml
+++ b/examples/json-producer/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <packaging>jar</packaging>
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.couchbase.client</groupId>
     <artifactId>kafka-connect-couchbase</artifactId>
     <packaging>jar</packaging>
-    <version>4.2.7-SNAPSHOT</version>
+    <version>4.2.7.1-NDSNAP</version>
     <name>Kafka Connector for Couchbase</name>
     <organization>
         <name>Couchbase, Inc.</name>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     </developers>
 
     <properties>
-        <java-compat.version>11</java-compat.version>
+        <java-compat.version>1.8</java-compat.version>
         <kafka.version>2.8.2</kafka.version>
         <dcp-client.version>0.52.0</dcp-client.version>
         <java-client.version>3.7.5</java-client.version>
@@ -256,7 +256,7 @@
                 <version>3.10.1</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <release>8</release>
+                    <release>11</release>
                     <annotationProcessorPaths>
                         <!-- Save Javadoc for use in Kafka config definitions. -->
                         <annotationProcessorPath>

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -150,7 +150,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
             String value = response.secretString();
 
             try {
-                secretJson = new ObjectMapper().readValue(value, new TypeReference<>() {
+                secretJson = new ObjectMapper().readValue(value, new TypeReference<Map<String, String>>() {
                 });
             } catch (Exception e) {
                 log.error("Unexpected value of a secret's structure", e);

--- a/src/main/java/com/couchbase/connect/kafka/config/source/SourceBehaviorConfig.java
+++ b/src/main/java/com/couchbase/connect/kafka/config/source/SourceBehaviorConfig.java
@@ -20,7 +20,6 @@ import com.couchbase.client.core.annotation.Stability;
 import com.couchbase.connect.kafka.StreamFrom;
 import com.couchbase.connect.kafka.filter.Filter;
 import com.couchbase.connect.kafka.handler.source.CouchbaseHeaderSetter;
-import com.couchbase.connect.kafka.handler.source.SourceHandler;
 import com.couchbase.connect.kafka.util.TopicMap;
 import com.couchbase.connect.kafka.util.config.annotation.Default;
 import org.apache.kafka.common.config.ConfigDef;
@@ -71,14 +70,17 @@ public interface SourceBehaviorConfig {
 
   /**
    * The fully-qualified class name of the source handler to use.
-   * The source handler determines how the Couchbase document is converted into a Kafka record.
+   * The source handler determines how the Couchbase document is converted into a
+   * Kafka record.
    * <p>
-   * The class must implement either `com.couchbase.connect.kafka.handler.source.SourceHandler`
+   * The class must implement either
+   * `com.couchbase.connect.kafka.handler.source.SourceHandler`
    * or `com.couchbase.connect.kafka.handler.source.MultiSourceHandler`.
    * <p>
    * To publish JSON messages identical to the Couchbase documents, use
    * `com.couchbase.connect.kafka.handler.source.RawJsonSourceHandler`
-   * and set `value.converter` to `org.apache.kafka.connect.converters.ByteArrayConverter`.
+   * and set `value.converter` to
+   * `org.apache.kafka.connect.converters.ByteArrayConverter`.
    * <p>
    * When using a custom source handler that filters out certain messages,
    * consider also configuring `couchbase.black.hole.topic`.
@@ -98,20 +100,24 @@ public interface SourceBehaviorConfig {
    * <p>
    * - *`key`* - The Couchbase document ID.
    * <p>
-   * - *`qualifiedKey`* - The document's scope, collection, and document ID, delimited by dots.
+   * - *`qualifiedKey`* - The document's scope, collection, and document ID,
+   * delimited by dots.
    * Example: `myScope.myCollection.myDocumentId`
    * <p>
    * - *`cas`* - The document's "compare and swap" value.
    * <p>
-   * - *`partition`* - The index of the Couchbase partition the document came from.
+   * - *`partition`* - The index of the Couchbase partition the document came
+   * from.
    * <p>
-   * - *`partitionUuid`* - Identifies the history branch of the partition the document came from.
+   * - *`partitionUuid`* - Identifies the history branch of the partition the
+   * document came from.
    * <p>
    * - *`seqno`* - The DCP sequence number of the event.
    * <p>
    * - *`rev`* - The revision number of the event.
    * <p>
-   * - *`expiry`* - The epoch second when the document expires, or null if the document has no expiry (or if the event is a deletion).
+   * - *`expiry`* - The epoch second when the document expires, or null if the
+   * document has no expiry (or if the event is a deletion).
    *
    * @since 4.2.5
    */
@@ -120,7 +126,8 @@ public interface SourceBehaviorConfig {
   List<String> headers();
 
   static ConfigDef.Validator headersValidator() {
-    return validate((List<String> headers) -> new CouchbaseHeaderSetter("somePrefix", headers), "Zero or more of " + CouchbaseHeaderSetter.validHeaders());
+    return validate((List<String> headers) -> new CouchbaseHeaderSetter("somePrefix", headers),
+        "Zero or more of " + CouchbaseHeaderSetter.validHeaders());
   }
 
   /**
@@ -129,7 +136,8 @@ public interface SourceBehaviorConfig {
    * <p>
    * For example, if `couchbase.headers` is set to `bucket,qualifiedKey`
    * and `header.name.prefix` is set to `example.`
-   * then records will have headers named `example.bucket` and `example.qualifiedKey`.
+   * then records will have headers named `example.bucket` and
+   * `example.qualifiedKey`.
    *
    * @since 4.2.5
    */
@@ -152,12 +160,14 @@ public interface SourceBehaviorConfig {
   Class<? extends Filter> eventFilter();
 
   /**
-   * If this property is non-blank, the connector publishes a tiny synthetic record
+   * If this property is non-blank, the connector publishes a tiny synthetic
+   * record
    * to this topic whenever the Filter or SourceHandler ignores a source event.
    * <p>
    * This lets the connector tell the Kafka Connect framework about the
    * source offset of the ignored event. Otherwise, a long sequence of ignored
-   * events in a low-traffic deployment might cause the stored source offset to lag
+   * events in a low-traffic deployment might cause the stored source offset to
+   * lag
    * too far behind the current source offset, which can lead to rollbacks to zero
    * when the connector is restarted.
    * <p>
@@ -171,11 +181,14 @@ public interface SourceBehaviorConfig {
   String blackHoleTopic();
 
   /**
-   * If `couchbase.stream.from` is `SAVED_OFFSET_OR_NOW`, and this property is non-blank,
-   * on startup the connector publishes to the named topic one tiny synthetic record
+   * If `couchbase.stream.from` is `SAVED_OFFSET_OR_NOW`, and this property is
+   * non-blank,
+   * on startup the connector publishes to the named topic one tiny synthetic
+   * record
    * for each source partition that does not yet have a saved offset.
    * <p>
-   * This lets the connector initialize the missing source offsets to "now" (the current
+   * This lets the connector initialize the missing source offsets to "now" (the
+   * current
    * state of Couchbase).
    * <p>
    * The synthetic records have a value of null, and the same key:
@@ -183,7 +196,8 @@ public interface SourceBehaviorConfig {
    * <p>
    * Consumers of this topic must ignore (or tolerate) these records.
    * <p>
-   * If you specify a value for `couchbase.black.hole.topic`, specify the same value here.
+   * If you specify a value for `couchbase.black.hole.topic`, specify the same
+   * value here.
    *
    * @since 4.2.4
    */
@@ -199,7 +213,8 @@ public interface SourceBehaviorConfig {
 
   /**
    * If true, Couchbase Server will omit the document content when telling the
-   * connector about a change. The document key and metadata will still be present.
+   * connector about a change. The document key and metadata will still be
+   * present.
    * <p>
    * If you don't care about the content of changed documents, enabling
    * this option is a great way to reduce the connector's network bandwidth
@@ -228,7 +243,8 @@ public interface SourceBehaviorConfig {
   StreamFrom streamFrom();
 
   /**
-   * If you wish to stream from all collections within a scope, specify the scope name here.
+   * If you wish to stream from all collections within a scope, specify the scope
+   * name here.
    * <p>
    * If you specify neither "couchbase.scope" nor "couchbase.collections",
    * the connector will stream from all collections of all scopes in the bucket.
@@ -239,7 +255,8 @@ public interface SourceBehaviorConfig {
   String scope();
 
   /**
-   * If you wish to stream from specific collections, specify the qualified collection
+   * If you wish to stream from specific collections, specify the qualified
+   * collection
    * names here, separated by commas. A qualified name is the name of the scope
    * followed by a dot (.) and then the name of the collection. For example:
    * "tenant-foo.invoices".

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -16,7 +16,6 @@
  */
 package com.amazonaws.kafka.config.providers;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -25,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -38,15 +36,17 @@ import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundExce
 public class SecretsManagerConfigProviderTest {
 
     Map<String, Object> props;
+
     @BeforeEach
     public void setup() {
         props = new HashMap<>();
         props.put("config.providers", "secretsmanager");
-        props.put("config.providers.secretsmanager.class", "com.amazonaws.kafka.config.providers.MockedSecretsManagerConfigProvider");
+        props.put("config.providers.secretsmanager.class",
+                "com.amazonaws.kafka.config.providers.MockedSecretsManagerConfigProvider");
         props.put("config.providers.secretsmanager.param.region", "us-west-2");
         props.put("config.providers.secretsmanager.param.NotFoundStrategy", "fail");
     }
-    
+
     @Test
     public void testExistingKeys() {
         props.put("username", "${secretsmanager:AmazonMSK_TestKafkaConfig:username}");
@@ -60,7 +60,9 @@ public class SecretsManagerConfigProviderTest {
 
     @Test
     public void testExistingKeysViaArn() {
-        String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret", StandardCharsets.UTF_8);
+        String arn = URLEncoder.encode(
+                "arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret",
+                StandardCharsets.UTF_8);
         props.put("username", "${secretsmanager:" + arn + ":username}");
         props.put("password", "${secretsmanager:" + arn + ":password}");
 
@@ -72,7 +74,9 @@ public class SecretsManagerConfigProviderTest {
 
     @Test
     public void testExistingKeysViaArnWithEncodedValue() {
-        String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret%3A", StandardCharsets.UTF_8);
+        String arn = URLEncoder.encode(
+                "arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret%3A",
+                StandardCharsets.UTF_8);
         props.put("username", "${secretsmanager:" + arn + ":username}");
         props.put("password", "${secretsmanager:" + arn + ":password}");
 
@@ -98,9 +102,9 @@ public class SecretsManagerConfigProviderTest {
     public void testTtl() {
         props.put("username", "${secretsmanager:AmazonMSK_TestKafkaConfig:username?ttl=60000}");
         props.put("password", "${secretsmanager:AmazonMSK_TestKafkaConfig:password}");
-        
+
         CustomConfig testConfig = new CustomConfig(props);
-        
+
         assertEquals("John", testConfig.getString("username"));
         assertEquals("Password123", testConfig.getString("password"));
     }
@@ -108,21 +112,21 @@ public class SecretsManagerConfigProviderTest {
     @Test
     public void testNonExistingSecret() {
         props.put("notFound", "${secretsmanager:notFound:noKey}");
-        assertThrows(ResourceNotFoundException.class, () ->new CustomConfig(props));
+        assertThrows(ResourceNotFoundException.class, () -> new CustomConfig(props));
     }
-    
+
     @Test
     public void testNonExistingKey() {
         props.put("notFound", "${secretsmanager:AmazonMSK_TestKafkaConfig:noKey}");
-        assertThrows(ConfigException.class, () ->new CustomConfig(props));
+        assertThrows(ConfigException.class, () -> new CustomConfig(props));
     }
-    
+
     static class CustomConfig extends AbstractConfig {
         final static String DEFAULT_DOC = "Default Doc";
         final static ConfigDef CONFIG = new ConfigDef()
                 .define("username", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
-                .define("password", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
-                ;
+                .define("password", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC);
+
         public CustomConfig(Map<?, ?> originals) {
             super(CONFIG, originals);
         }

--- a/src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java
+++ b/src/test/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandlerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 @ExtendWith(MockitoExtension.class)
 class NDSourceHandlerTest {
@@ -51,37 +50,56 @@ class NDSourceHandlerTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         handler = new NDSourceHandler();
+        mockEvent = mock(DocumentEvent.class);
+        mockParams = mock(SourceHandlerParams.class);
+        mockBuilder = mock(SourceRecordBuilder.class);
+        mockS3Client = mock(S3Client.class);
         objectMapper = new ObjectMapper();
+
+        // Set up common mocks
+        lenient().when(mockParams.documentEvent()).thenReturn(mockEvent);
+        lenient().when(mockParams.topic()).thenReturn("test-topic");
     }
 
-    private void initializeHandler(boolean useS3, String fields, long s3Threshold, String cloudEventType,
-            String s3Suffix) {
-        Map<String, String> config = new HashMap<>();
-        config.put("couchbase.custom.handler.nd.fields", fields);
-        config.put("couchbase.custom.handler.nd.cloudevent.type", cloudEventType);
-        if (useS3) {
-            config.put("couchbase.custom.handler.nd.s3.bucket", "test-bucket");
-            config.put("couchbase.custom.handler.nd.s3.region", "us-west-2");
-            config.put("couchbase.custom.handler.nd.s3.threshold", String.valueOf(s3Threshold));
-            config.put("couchbase.custom.handler.nd.s3.suffix", s3Suffix);
+    private void initializeHandler(boolean enableS3, String fields, long threshold, String eventType, String suffix) {
+        initializeHandler(enableS3, fields, threshold, eventType, suffix, null, null);
+    }
+
+    private void initializeHandler(boolean enableS3, String fields, long threshold, String eventType, String suffix,
+            String filterField, String filterValues) {
+        Map<String, String> props = new HashMap<>();
+        props.put("couchbase.custom.handler.nd.fields", fields);
+        props.put("couchbase.custom.handler.nd.cloud.event.type", eventType);
+
+        if (enableS3) {
+            props.put("couchbase.custom.handler.nd.s3.bucket", "test-bucket");
+            props.put("couchbase.custom.handler.nd.s3.region", "us-west-2");
+            props.put("couchbase.custom.handler.nd.s3.threshold", String.valueOf(threshold));
+            props.put("couchbase.custom.handler.nd.s3.suffix", suffix);
         }
 
-        handler.init(config);
+        if (filterField != null) {
+            props.put("couchbase.custom.handler.nd.filter.field", filterField);
+        }
+        if (filterValues != null) {
+            props.put("couchbase.custom.handler.nd.filter.values", filterValues);
+        }
+
+        handler.init(props);
     }
 
     @Test
     void testHandleMutationBelowS3Threshold() throws Exception {
         initializeHandler(true, "field1,field2,type", 100000, "test.event", ".json");
         String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
-        setupMockEvent(DocumentEvent.Type.MUTATION, "test-key", content, "test-bucket");
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
 
         SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
         SourceRecordBuilder result = handler.handle(params);
 
         assertNotNull(result);
-        assertEquals("test-key", result.key());
+        assertEquals("MDucot5/qbti~240924115010829", result.key());
 
         JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
         JsonNode data = jsonNode.get("data");
@@ -96,7 +114,7 @@ class NDSourceHandlerTest {
     void testHandleMutationAboveS3Threshold() throws Exception {
         initializeHandler(true, "*", 10, "test.event", ".json");
         String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
-        setupMockEvent(DocumentEvent.Type.MUTATION, "test-key", content, "test-bucket");
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
         when(mockEvent.bucket()).thenReturn("test-bucket");
         when(mockEvent.revisionSeqno()).thenReturn(1L);
 
@@ -106,7 +124,7 @@ class NDSourceHandlerTest {
         SourceRecordBuilder result = handler.handle(params);
 
         assertNotNull(result);
-        assertEquals("test-key", result.key());
+        assertEquals("MDucot5/qbti~240924115010829", result.key());
 
         JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
         JsonNode data = jsonNode.get("data");
@@ -119,14 +137,14 @@ class NDSourceHandlerTest {
 
         PutObjectRequest putObjectRequest = requestCaptor.getValue();
         assertEquals("test-bucket", putObjectRequest.bucket());
-        assertTrue(putObjectRequest.key().startsWith("directory/test-key/"));
+        assertTrue(putObjectRequest.key().startsWith("MDucot5/q/b/t/i/~240924115010829/"));
         assertTrue(putObjectRequest.key().endsWith(".json"));
     }
 
     @Test
     void testCloudEventHeaders() {
         initializeHandler(false, "field1,field2,type", 100000, "test.event", ".json");
-        setupMockEvent(DocumentEvent.Type.MUTATION, "test-key",
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829",
                 "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}", "test-bucket");
 
         SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
@@ -139,19 +157,19 @@ class NDSourceHandlerTest {
     @Test
     void testHandleExpiration() throws Exception {
         initializeHandler(false, "field1,field2,type", 100000, "test.event", ".s3");
-        setupMockEvent(DocumentEvent.Type.EXPIRATION, "test-key", null, "test-bucket");
+        setupMockEvent(DocumentEvent.Type.EXPIRATION, "MDucot5/qbti~240924115010829", null, "test-bucket");
 
         SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
         SourceRecordBuilder result = handler.handle(params);
 
         assertNotNull(result);
         assertEquals(Schema.STRING_SCHEMA, result.keySchema());
-        assertEquals("test-key", result.key());
+        assertEquals("MDucot5/qbti~240924115010829", result.key());
 
         JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
         JsonNode data = jsonNode.get("data");
         assertEquals("expiration", data.get("event").asText());
-        assertEquals("test-key", data.get("key").asText());
+        assertEquals("MDucot5/qbti~240924115010829", data.get("key").asText());
 
         verify(mockS3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -161,9 +179,10 @@ class NDSourceHandlerTest {
         String content = "{\"documents\":{\"1\": {\"docProps\":{\"id\":\"doc123\"}}}}";
         initializeHandler(true, "*", 10, "test.event", ".s3");
         handler.setS3Client(mockS3Client);
-        setupMockEvent(DocumentEvent.Type.MUTATION, "test-key",
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829",
                 content, "test-bucket");
         when(mockEvent.bucket()).thenReturn("test-bucket");
+        when(mockEvent.revisionSeqno()).thenReturn(123L); // Make sure revision number is set
 
         SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
         handler.handle(params);
@@ -174,23 +193,35 @@ class NDSourceHandlerTest {
 
         PutObjectRequest putObjectRequest = requestCaptor.getValue();
         assertEquals("test-bucket", putObjectRequest.bucket());
-        assertTrue(putObjectRequest.key().startsWith("test-key/"));
-        assertTrue(putObjectRequest.key().contains(("doc123")));
-        assertTrue(putObjectRequest.key().endsWith("0.json"));
+        assertTrue(putObjectRequest.key().startsWith("MDucot5/q/b/t/i/~240924115010829/"));
+        assertTrue(putObjectRequest.key().contains("doc123"));
+        assertTrue(putObjectRequest.key().endsWith("123.json")); // Should end with revision number
     }
 
     @Test
-    void testExtractDocPropsId() {
-        byte[] content = "{\"documents\":{\"1\": {\"docProps\":{\"id\":\"doc123\"}}}}".getBytes();
-        String docPropsId = handler.extractDocPropsId(content);
-        assertEquals("doc123", docPropsId);
+    void testDocPropsIdExtraction() throws Exception {
+        initializeHandler(true, "*", 100000, "test.event", ".json");
+        String content = "{\"documents\":{\"1\":{\"docProps\":{\"id\":\"doc123\"}}}}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        handler.handle(params); // This will trigger field extraction
+
+        String s3Key = handler.generateS3Key(mockEvent);
+        assertTrue(s3Key.contains("doc123"), "S3 key should contain the extracted docProps id");
     }
 
     @Test
-    void testExtractDocPropsIdWithInvalidJson() {
-        byte[] content = "invalid json".getBytes();
-        String docPropsId = handler.extractDocPropsId(content);
-        assertEquals("unknown", docPropsId);
+    void testDocPropsIdExtractionWithInvalidDocument() throws Exception {
+        initializeHandler(true, "*", 100000, "test.event", ".json");
+        String content = "{\"documents\":{\"1\":{\"wrongField\":\"value\"}}}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "test-key", content, "test-bucket");
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        handler.handle(params); // This will trigger field extraction
+
+        String s3Key = handler.generateS3Key(mockEvent);
+        assertTrue(s3Key.startsWith("directory/"), "S3 key should use directory format for invalid documents");
     }
 
     @Test
@@ -208,12 +239,13 @@ class NDSourceHandlerTest {
     }
 
     private void setupMockEvent(DocumentEvent.Type type, String key, String content, String bucket) {
-        when(mockEvent.type()).thenReturn(type);
-        when(mockEvent.key()).thenReturn(key);
-        when(mockEvent.bucket()).thenReturn(bucket);
-        if (content != null) {
-            when(mockEvent.content()).thenReturn(content.getBytes());
-        }
+        if (content == null)
+            content = "";
+        lenient().when(mockEvent.type()).thenReturn(type);
+        lenient().when(mockEvent.key()).thenReturn(key);
+        lenient().when(mockEvent.content()).thenReturn(content.getBytes());
+        lenient().when(mockEvent.bucket()).thenReturn(bucket);
+        lenient().when(mockEvent.revisionSeqno()).thenReturn(123L);
     }
 
     private void assertCloudEventHeaders(Iterable<Header> headers) {
@@ -241,49 +273,59 @@ class NDSourceHandlerTest {
     void testGenerateS3KeyForDirectory() {
         // Arrange
         DocumentEvent mockEvent = Mockito.mock(DocumentEvent.class);
-        Mockito.when(mockEvent.key()).thenReturn("testKey");
+        Mockito.when(mockEvent.key()).thenReturn("MDucot5/qbti~240924115010829");
         Mockito.when(mockEvent.revisionSeqno()).thenReturn(123L);
 
         // Act
         String result = handler.generateS3KeyForDirectory(mockEvent);
 
         // Assert
-        assertEquals("directory/testKey/123.json", result);
+        assertEquals("directory/MDucot5/qbti~240924115010829/123.json", result);
     }
 
     @Test
     void testHandleSpecificFieldsExtractionMutation() {
-        initializeHandler(true, "field1,fields2", 1000, "test.event", ".s3");
-        // Arrange
-        when(mockDocEvent.type()).thenReturn(DocumentEvent.Type.MUTATION);
-        when(mockDocEvent.content()).thenReturn("{\"field1\":\"value1\",\"field2\":\"value2\"}".getBytes());
-        when(mockDocEvent.key()).thenReturn("testKey");
-        when(mockDocEvent.bucket()).thenReturn("testBucket");
-        when(mockDocEvent.revisionSeqno()).thenReturn(123L);
-        // when(mockParams.documentEvent()).thenReturn(mockDocEvent);
+        // Initialize handler with specific fields to extract
+        initializeHandler(true, "field1,field2", 1000, "test.event", ".s3");
+
+        // Prepare test data with matching fields
+        String content = "{\"field1\":\"value1\",\"field2\":\"value2\"}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
+
+        // Initialize extractedFields by calling extractFields
+        Map<String, Object> fields = handler.extractFields(content.getBytes());
+        assertNotNull(fields, "Extracted fields should not be null");
+        assertFalse(fields.isEmpty(), "Extracted fields should not be empty");
+
         handler.setS3Client(mockS3Client);
+
         // Act
-        boolean result = handler.handleSpecificFieldsExtractionMutation(mockDocEvent, DocumentEvent.Type.MUTATION,
+        boolean result = handler.handleSpecificFieldsExtractionMutation(mockEvent, DocumentEvent.Type.MUTATION,
                 mockParams, mockBuilder);
 
         // Assert
-        assertTrue(result);
+        assertTrue(result, "Handler should successfully process the mutation");
         verify(mockBuilder).value(eq(null), any(byte[].class));
         verify(mockS3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
 
     @Test
     void testHandleSpecificFieldsExtractionMutationWithS3Upload() {
-        initializeHandler(true, "field1,fields2", 100, "test.event", ".s3");
-        // Arrange
+        // Initialize handler
+        initializeHandler(true, "field1,field2", 100, "test.event", ".s3");
+
+        // Prepare test data
         String largeContent = "{\"field1\":\"" + "a".repeat(200) + "\",\"field2\":\"value2\"}";
         when(mockDocEvent.type()).thenReturn(DocumentEvent.Type.MUTATION);
-        when(mockDocEvent.content()).thenReturn(largeContent.getBytes());
-        when(mockDocEvent.key()).thenReturn("testKey");
+        when(mockDocEvent.key()).thenReturn("MDucot5/qbti~240924115010829");
         when(mockDocEvent.bucket()).thenReturn("testBucket");
         when(mockDocEvent.revisionSeqno()).thenReturn(123L);
-        // when(mockParams.documentEvent()).thenReturn(mockDocEvent);
+
+        // Need to extract fields first
+        handler.extractFields(largeContent.getBytes());
+
         handler.setS3Client(mockS3Client);
+
         // Act
         boolean result = handler.handleSpecificFieldsExtractionMutation(mockDocEvent, DocumentEvent.Type.MUTATION,
                 mockParams, mockBuilder);
@@ -296,10 +338,18 @@ class NDSourceHandlerTest {
 
     @Test
     void testHandleSpecificFieldsExtractionMutationWithInvalidJson() {
-        initializeHandler(true, "field1,fields2", 100, "test.event", ".s3");
-        // Arrange
-        when(mockDocEvent.content()).thenReturn("invalid json".getBytes());
+        // Initialize handler
+        initializeHandler(true, "field1,field2", 100, "test.event", ".s3");
+
+        // Prepare test data
+        byte[] invalidContent = "invalid json".getBytes();
+        lenient().when(mockDocEvent.content()).thenReturn(invalidContent);
+
+        // Need to extract fields first
+        handler.extractFields(invalidContent);
+
         handler.setS3Client(mockS3Client);
+
         // Act
         boolean result = handler.handleSpecificFieldsExtractionMutation(mockDocEvent, DocumentEvent.Type.MUTATION,
                 mockParams, mockBuilder);
@@ -313,13 +363,12 @@ class NDSourceHandlerTest {
     @Test
     void testGenerateS3Key() {
         // Arrange
-        String originalKey = "MDucot5/qbti~240924115010829";
-        long revisionSeqno = 123L;
-        byte[] content = "{\"documents\":{\"1\":{\"docProps\":{\"id\":\"doc123\"}}}}".getBytes();
+        initializeHandler(true, "*", 100000, "test.event", ".json");
+        String content = "{\"documents\":{\"1\":{\"docProps\":{\"id\":\"doc123\"}}}}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
 
-        when(mockEvent.key()).thenReturn(originalKey);
-        when(mockEvent.revisionSeqno()).thenReturn(revisionSeqno);
-        when(mockEvent.content()).thenReturn(content);
+        // Initialize extractedFields
+        handler.extractFields(content.getBytes());
 
         // Act
         String result = handler.generateS3Key(mockEvent);
@@ -332,19 +381,122 @@ class NDSourceHandlerTest {
     @Test
     void testGenerateS3KeyForNonDocumentEvent() {
         // Arrange
-        String originalKey = "shortKey";
-        long revisionSeqno = 456L;
-        byte[] content = "{}".getBytes();
+        initializeHandler(true, "*", 100000, "test.event", ".json");
+        String content = "{}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "shortKey", content, "test-bucket");
 
-        when(mockEvent.key()).thenReturn(originalKey);
-        when(mockEvent.revisionSeqno()).thenReturn(revisionSeqno);
-        when(mockEvent.content()).thenReturn(content);
+        // Initialize extractedFields
+        handler.extractFields(content.getBytes());
 
         // Act
         String result = handler.generateS3Key(mockEvent);
 
         // Assert
-        String expectedKey = "directory/shortKey/456.json";
+        String expectedKey = "directory/shortKey/123.json";
         assertEquals(expectedKey, result);
+    }
+
+    @Test
+    void testHandleMutationWithFieldFiltering() throws Exception {
+        // Initialize with field filtering
+        initializeHandler(true, "field1,field2", 100000, "test.event", ".json", "field1", "value1");
+        String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        SourceRecordBuilder result = handler.handle(params);
+
+        assertNotNull(result);
+        assertEquals("MDucot5/qbti~240924115010829", result.key());
+
+        JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
+        JsonNode data = jsonNode.get("data");
+        assertEquals("value1", data.get("field1").asText());
+        assertEquals("value2", data.get("field2").asText());
+    }
+
+    @Test
+    void testHandleMutationWithFieldFilteringNoMatch() throws Exception {
+        // Initialize with field filtering that won't match
+        initializeHandler(true, "field1,field2", 100000, "test.event", ".json", "field1", "nonmatching");
+        String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
+
+        // Set up only the necessary mocks
+        when(mockEvent.content()).thenReturn(content.getBytes());
+        when(mockEvent.type()).thenReturn(DocumentEvent.Type.MUTATION);
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        SourceRecordBuilder result = handler.handle(params);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testHandleMutationWithNoFieldFiltering() throws Exception {
+        // Initialize without field filtering
+        initializeHandler(true, "field1,field2", 100000, "test.event", ".json", null, null);
+        String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        SourceRecordBuilder result = handler.handle(params);
+
+        assertNotNull(result);
+        assertEquals("MDucot5/qbti~240924115010829", result.key());
+
+        JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
+        JsonNode data = jsonNode.get("data");
+        assertEquals("value1", data.get("field1").asText());
+        assertEquals("value2", data.get("field2").asText());
+    }
+
+    @Test
+    void testHandleMutationWithInvalidJson() throws Exception {
+        initializeHandler(true, "field1,field2", 100000, "test.event", ".json");
+
+        // Set up only the necessary mocks
+        when(mockEvent.content()).thenReturn("invalid json".getBytes());
+        when(mockEvent.type()).thenReturn(DocumentEvent.Type.MUTATION);
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        SourceRecordBuilder result = handler.handle(params);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractFieldsWithMissingFields() throws Exception {
+        // Test with no fields specified
+        initializeHandler(true, null, 100000, "test.event", ".json");
+        String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        SourceRecordBuilder result = handler.handle(params);
+
+        assertNotNull(result);
+        JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
+        JsonNode data = jsonNode.get("data");
+        assertNotNull(data.get("field1"));
+        assertNotNull(data.get("field2"));
+        assertNotNull(data.get("type"));
+    }
+
+    @Test
+    void testExtractFieldsWithEmptyFields() throws Exception {
+        // Test with empty fields
+        initializeHandler(true, "", 100000, "test.event", ".json");
+        String content = "{\"field1\":\"value1\",\"field2\":\"value2\",\"type\":\"type1\"}";
+        setupMockEvent(DocumentEvent.Type.MUTATION, "MDucot5/qbti~240924115010829", content, "test-bucket");
+
+        SourceHandlerParams params = new SourceHandlerParams(mockEvent, "test-topic", false);
+        SourceRecordBuilder result = handler.handle(params);
+
+        assertNotNull(result);
+        JsonNode jsonNode = objectMapper.readTree((byte[]) result.value());
+        JsonNode data = jsonNode.get("data");
+        assertNotNull(data.get("field1"));
+        assertNotNull(data.get("field2"));
+        assertNotNull(data.get("type"));
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve performance by only extracting properties from the document body once, enhance the filtering capabilities of the `NDSourceHandler`, and clean up formatting in the `SourceBehaviorConfig` class.

### Java Compatibility Updates:
* Updated `maven.compiler.source` and `maven.compiler.target` to Java 11 in `examples/json-producer/pom.xml`.
* Changed `java-compat.version` to 1.8 in `pom.xml`.
* Updated the `<release>` configuration to 11 in `pom.xml`.

### Enhancements to `NDSourceHandler`:
* Added new configuration properties for filtering documents based on JSON fields: `FILTER_FIELD_CONFIG`, `FILTER_VALUES_CONFIG`, and `FILTER_ALLOW_NULL_CONFIG` in `NDSourceHandler.java`. [[1]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aR65-R67) [[2]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aL81-R91)
* Implemented field extraction and filtering logic in `NDSourceHandler.java`. [[1]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aR101-R176) [[2]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aR191-R212) [[3]](diffhunk://#diff-24db8b134c725874c95eb254fd5fd0384a73b3957219e9ec7a07bf134e0e318aR304-R313)
* Refactored the `generateS3Key` method to use the extracted document properties ID.

### Formatting Improvements:
* Cleaned up line breaks and formatting in `SourceBehaviorConfig.java` to improve readability. [[1]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L74-R83) [[2]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L101-R120) [[3]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L123-R130) [[4]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L132-R140) [[5]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L155-R170) [[6]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L174-R200) [[7]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L202-R217) [[8]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L231-R247) [[9]](diffhunk://#diff-0773a484b9a86a918b7573b0aab543e6f02e3451d51b3da7c6509fa492be6c51L242-R259)