### PR TITLE
Use DCP event timestamp for CloudEvent time (with fallback)

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/handler/source/DocumentEvent.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/source/DocumentEvent.java
@@ -21,6 +21,8 @@ import com.couchbase.client.dcp.highlevel.DocumentChange;
 import com.couchbase.client.dcp.highlevel.Mutation;
 import com.couchbase.connect.kafka.config.source.DcpConfig;
 
+import java.time.Instant;
+
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -133,6 +135,13 @@ public class DocumentEvent {
   }
 
   /**
+   * Returns the Couchbase change timestamp for this event.
+   */
+  public Instant timestamp() {
+    return change.getTimestamp();
+  }
+
+  /**
    * Returns true if the document was created or updated,
    * otherwise false.
    */
@@ -151,7 +160,8 @@ public class DocumentEvent {
   }
 
   /**
-   * Returns information about the scope and collection associated with this event.
+   * Returns information about the scope and collection associated with this
+   * event.
    */
   public CollectionMetadata collectionMetadata() {
     return new CollectionMetadata(change);

--- a/src/main/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandler.java
+++ b/src/main/java/com/netdocuments/connect/kafka/handler/source/NDSourceHandler.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Instant;
+
 import java.util.*;
 
 /**
@@ -528,7 +529,8 @@ public class NDSourceHandler extends RawJsonWithMetadataSourceHandler {
     data.put("id", documentEvent.key() + "-" + documentEvent.revisionSeqno());
     data.put("type", getCloudEventType(documentEvent, typeSuffix));
     data.put("source", "netdocs://ndserver/" + documentEvent.bucket());
-    data.put("time", Instant.now().toString());
+    Instant ts = documentEvent.timestamp();
+    data.put("time", (ts != null ? ts : Instant.now()).toString());
     data.put("datacontenttype", "application/json;charset=utf-8");
     data.put("partitionkey", documentEvent.key());
     data.put("traceparent", UUID.randomUUID().toString());


### PR DESCRIPTION
This PR changes the CloudEvent `time` value to use the Couchbase DCP event timestamp, with a safe fallback to `Instant.now()` if the timestamp is unavailable. It also exposes `timestamp()` on `DocumentEvent` to surface the underlying DCP `DocumentChange` timestamp.

Changes:
- com.couchbase.connect.kafka.handler.source.DocumentEvent: add `public Instant timestamp()` returning `change.getTimestamp()`
- com.netdocuments.connect.kafka.handler.source.NDSourceHandler: set CloudEvent `time` using `documentEvent.timestamp()` with fallback to `Instant.now()`

Build: `./mvnw -q -DskipTests package` passed locally.

Rationale:
- Align CloudEvent time with the actual Couchbase change time (more useful for ordering and time-based processing)
- Preserve previous behavior when timestamp is not available by falling back to the publish time.



---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author