### PR TITLE
AB#418586 Bump version to 4.2.7.3-NDSNAP for watchdog timeout fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.couchbase.client</groupId>
     <artifactId>kafka-connect-couchbase</artifactId>
     <packaging>jar</packaging>
-    <version>4.2.7.2-NDSNAP</version>
+    <version>4.2.7.3-NDSNAP</version>
     <name>Kafka Connector for Couchbase</name>
     <organization>
         <name>Couchbase, Inc.</name>


### PR DESCRIPTION
## Summary
Bumps version from 4.2.7.2-NDSNAP to 4.2.7.3-NDSNAP to enable deployment of PR #21 watchdog timeout fixes.

## Background
PR #21 (merged) includes critical fixes for workers getting stuck in "converting to source records" state:
- S3 client timeout configuration (30s API call, 10s per-attempt)
- Field extraction timeout wrapper (10 seconds)
- JSON parsing optimizations (early termination, skipChildren)
- S3 upload retry logic (3 retries)

## Changes
- Increment `pom.xml` version to `4.2.7.3-NDSNAP`

## Next Steps After Merge
1. Run pipeline to build new connector library artifact
2. Update IAC to reference version `4.2.7.3-NDSNAP`
3. Deploy to environment

## References
- ADO: [AB#418586](https://netdocuments.visualstudio.com/51a01ed7-b5e7-423c-8ef0-ea474af0bef2/_workitems/edit/418586)
- Original Fix: PR #21
- Slack: Documents team discussion 2025-12-11

## Test Plan
- [ ] Build pipeline generates `couchbase-kafka-connect-couchbase-4.2.7.3-NDSNAP.zip`
- [ ] IAC update references new version
- [ ] Monitor worker logs for watchdog timeout warnings after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)