### PR TITLE
Add security scans workflow

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -1,0 +1,16 @@
+name: Security Scans
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  security:
+    uses: NetDocs-Security/gh-security-workflows/.github/workflows/security-scans.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add the centrally managed Security Scans workflow
- enable this repository to participate in the enterprise-required `security/final-gate` check
- use the standard onboarding configuration from `NetDocs-Security/gh-security-workflows`

## Notes
- This PR was created automatically by the enterprise rollout tool.